### PR TITLE
Fixed tiny bug that caused the legend circles to not be completely filled in

### DIFF
--- a/R/make_achv_shape.R
+++ b/R/make_achv_shape.R
@@ -20,8 +20,8 @@
 
 make_achv_shape <- function(x){
   if(is.na(x)){
-    fontawesome::fa("circle", fill = "white", height = "2em") %>% as.character() %>% gt::html()
+    fontawesome::fa("circle", fill = "white", height = "2em", prefer_type = "solid") %>% as.character() %>% gt::html()
   } else {
-    fontawesome::fa("circle", fill = x, height = "2em") %>% as.character() %>% gt::html()
+    fontawesome::fa("circle", fill = x, height = "2em", prefer_type = "solid") %>% as.character() %>% gt::html()
   }
 }

--- a/R/make_chg_shape.R
+++ b/R/make_chg_shape.R
@@ -27,14 +27,14 @@ make_chg_shape <- function(change_dir){
   alpha = 0.75
   # Extra if statement to catch NA cells
   if(is.na(change_dir)){
-    logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em", prefer_type = "regular")
+    logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em", prefer_type = "solid")
   } else {
     if (change_dir == "increase") {
       logo_out <- fontawesome::fa("circle-arrow-up", fill = glitr::genoa_light, fill_opacity = alpha, height = "2em")
     } else if (change_dir == "decrease"){
       logo_out <- fontawesome::fa("circle-arrow-down", fill = glitr::old_rose_light, fill_opacity = alpha, height = "2em")
     } else if (change_dir == "not applicable" | is.na(change_dir)) {
-      logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em", prefer_type = "regular")
+      logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em", prefer_type = "solid")
     } 
   }
   logo_out %>% as.character() %>% gt::html()

--- a/R/make_chg_shape.R
+++ b/R/make_chg_shape.R
@@ -27,14 +27,14 @@ make_chg_shape <- function(change_dir){
   alpha = 0.75
   # Extra if statement to catch NA cells
   if(is.na(change_dir)){
-    logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em")
+    logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em", prefer_type = "regular")
   } else {
     if (change_dir == "increase") {
       logo_out <- fontawesome::fa("circle-arrow-up", fill = glitr::genoa_light, fill_opacity = alpha, height = "2em")
     } else if (change_dir == "decrease"){
       logo_out <- fontawesome::fa("circle-arrow-down", fill = glitr::old_rose_light, fill_opacity = alpha, height = "2em")
     } else if (change_dir == "not applicable" | is.na(change_dir)) {
-      logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em")
+      logo_out <- fontawesome::fa("circle", fill = glitr::trolley_grey_light, fill_opacity = alpha, height = "2em", prefer_type = "regular")
     } 
   }
   logo_out %>% as.character() %>% gt::html()


### PR DESCRIPTION
`fontawesome::fa()` ([link](https://github.com/rstudio/fontawesome/blob/main/R/fa.R)) has a `prefer_type` argument that defaults to `regular`. Changed the option to `solid` to ensure filled circles are, indeed, filled.